### PR TITLE
Add skeleton guides

### DIFF
--- a/guides/code.md
+++ b/guides/code.md
@@ -1,0 +1,10 @@
+# Guides for Writing Code
+
+* follow language conventions
+* create coding style / conventions
+* use linter / static checker
+* proper names
+* ending newline
+* code has to compile to be committed; it's not necessary to work
+* no trailing whitespaces
+* consistency: bad way but consistent is much better than two good ways - only indent with tabs or spaces, not both

--- a/guides/content.md
+++ b/guides/content.md
@@ -1,0 +1,16 @@
+# Guides for Content Writing
+
+## Formatting Content
+
+- Use one line (and only one line) per sentence.
+  That is, a sentence (ending in dot - `.`, colon - `:`, question mark - `?`, exclamation mark - `!`, semicolon `;`) won't be on two lines.
+  And a line won't have (parts of) two sentences.
+- When listing snippets, aim to end the preceding description paragraph with colon - `:`.
+- Use italic font for translations, for alternative names or for de-abbreviations.
+- Add a blank line after each section heading.
+- Add ending newline.
+- No trailing whitespaces.
+
+## Syntax
+
+- Do spell checking (link to Vim).

--- a/guides/docker.md
+++ b/guides/docker.md
@@ -1,0 +1,10 @@
+# Guides for Using Docker
+
+- Common environment
+- Use of pre-built images (DockerHub)
+- Dockerfile
+- Startup services
+- Docker container / image names
+- Port mapping
+- Folder mapping
+- docker-compose

--- a/guides/git.md
+++ b/guides/git.md
@@ -1,0 +1,11 @@
+# Guides for using Git
+
+- config author, email
+- same name for sign off
+- commit writing
+- use component / path as prefix for commit message
+- update author, GIT_COMMITTER_NAME, GIT_AUTHOR_NAME
+- git push --force
+- git commit --amend
+- git squash
+- git rebase

--- a/guides/github.md
+++ b/guides/github.md
@@ -1,0 +1,27 @@
+# Guides for Using GitHub
+
+## Creating a Repository
+
+## Contributing to a Repository
+
+## Reviewing Contributions
+
+## Managing a Repository
+
+## Steps
+
+* Creating a contribution: PR, new branch name
+* create draft PR until PR is ready; get early reviews while still being WIP (work-in-progress)
+* Allow maintainer edits (default)
+* git commit --amend, push --force
+* teams
+* rebase & merge
+* review + approve
+* squash unitary commits in PR
+* comments, suggestions
+* mark conversation as resolved, once comment has been addressed - to know this has been solved
+* review is an iterative process, it's likely tot take several rounds: create, review, update, review, update, review
+* protected branches
+* linked issues
+* create issues to not forget problems
+* GitHub projects

--- a/guides/markdown.md
+++ b/guides/markdown.md
@@ -1,0 +1,16 @@
+# Guides for using Markdown
+
+Reference content guide
+
+* Use single backticks instead of triple backticks for inline text.
+  Use triple backticks for blocks of code / commands.
+* Separate block items (lists, snippets of code / commands) by a new line.
+  That is, every list of items should be preceded and succeeded by a new line.
+  Same goes for blocks of code in triple backticks.
+* Separate subsequent commands within a snippet by empty lines.
+* When using backticks aim to add the language the snippet belongs to (`C`, `Python`).
+  Only use `Bash` for shell scripts, not commands and their output.
+  GitHub and other rendering engines will also highlight command output, that may contain keywords (that shouldn't be highlighted as part of the output).
+* Use single backticks for commands, function names, arguments, parameters.
+* Image sizes
+* References / footnotes

--- a/guides/media.md
+++ b/guides/media.md
@@ -1,0 +1,12 @@
+# Guides for Working with Media Files
+
+Media files includes images / diagrams, audio and video files.
+
+- Create diagrams in draw.io
+- Transparent background; create transparent background
+- Prefer vector graphics (SVG, PDF)
+- Generate animated GIFs from images via ffmpeg
+- Command for text to image
+- Generating favicon
+- Command line conversion between image formats
+- Media file information (`mediainfo`)

--- a/guides/quiz.md
+++ b/guides/quiz.md
@@ -1,0 +1,10 @@
+# Guides for Quizzes
+
+Questions part of content and for separate assessment
+
+- Reference quiz question format
+- Preference: 4 answers (1 correct), 5 answers (2 correct), 7 answers (3 correct) - mention number of correct answers
+- Ideally short questions, short answers
+- Avoid True / True, True / False, False / True, False / False questions
+- Use **not**, or NOT, or **NOT** to highlight important words
+- Templated questions require support in publishing infrastructure


### PR DESCRIPTION
Add guides on writing content, code and on using the corresponding tools.

This PR would present draft / skeleton ideas for different guides. We will then integrate the PR and then create PRs with actual contents for each type of guide.

I find this useful to agree on a structure for guides.

For each guide, I suggest we would general guidelines and best practices and then add a section `OpenEdu Conventions` with our conventions based on these guides.