### PR TITLE
fix: Update default branch to trigger linting pipeline

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -3,7 +3,7 @@ name: Linting Workflow
 on:
   pull_request:
     branches:
-      - master
+      - main
 
 jobs:
   super-linter:


### PR DESCRIPTION
Rename `master` branch to `main`.