### PR TITLE
config: Add `media/` folder to the "Roles" chapter

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -25,6 +25,8 @@ docusaurus:
       - Roles:
           - Overview:
               path: chapters/roles/overview
+              extra:
+                - media/
               subsections:
                 - Reading: reading/read.md
       - Support Infrastructure:


### PR DESCRIPTION
# Prerequisite Checklist

- [x] Read the [contribution guidelines](https://github.com/open-education-hub/ccas-internal/blob/main/CONTRIBUTING.md#pull-requests) regarding submitting new changes to the project;
- [x] Tested your changes against relevant architectures and platforms;
- [n/a] Updated relevant documentation (if needed).

## Description of changes

PR #52 introduced new media files for the "Roles" chapter without adding that folder to the `config.yaml` file, causing a [builder error](https://github.com/open-education-hub/methodology/actions/runs/7346497274/job/20001360167#step:5:151). This PR addresses this issue by adding the path to the `media/` folder to said config file.
